### PR TITLE
Setup Basic Debugger to be used in Vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN npm ci
 COPY . .
 
 # Expose the port the app runs in
-EXPOSE 3000
+EXPOSE 3000 9229
 
 # Serve the app
 CMD ["npm", "start"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
         }
     },
     "forwardPorts": [
-        3000
+        3000,
+        9229
     ],
     "postCreateCommand": "npm install"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch and Debug",
+      "program": "${workspaceFolder}/app.js",
+      "runtimeExecutable": "node",
+      "runtimeArgs": [
+        "--inspect-brk=0.0.0.0:9229"
+      ],
+      "skipFiles": ["<node_internals>/**"],
+      "outFiles": ["${workspaceFolder}/**/*.js"]
+    }
+  ]
+}


### PR DESCRIPTION
- This setup adds additional functionality of a debugger into `vscode` tooling
- devs can now use the `launch.json` configuration inside vscode which will start the node application with a attachment to the debugger.
![image](https://github.com/sl-NZ/bookshop/assets/14116973/6814e0d6-5124-442d-8eb4-39bd23e4d741)
