### PR TITLE
Basic Stripe Scaffolding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,12 @@
                 "dbaeumer.vscode-eslint",
                 "esbenp.prettier-vscode",
                 "ms-azuretools.vscode-docker"
-            ]
+            ],
+            "settings": {
+                "[handlebars]": {
+                    "editor.defaultFormatter": "vscode.html-language-features"
+                }
+            }
         }
     },
     "forwardPorts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,5 +22,5 @@
         3000,
         9229
     ],
-    "postCreateCommand": "npm install"
+    "postCreateCommand": "npm install;git config --global --add safe.directory /workspaces/bookshop"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
             "extensions": [
                 "dbaeumer.vscode-eslint",
                 "esbenp.prettier-vscode",
-                "ms-azuretools.vscode-docker"
+                "ms-azuretools.vscode-docker",
+                "GitHub.vscode-pull-request-github"
             ],
             "settings": {
                 "[handlebars]": {

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Take home project
-This is a simple e-commerce application that a customer can use to purchase a book, but it's missing the payments functionality —  your goal is to integrate Stripe to get this application running!
+
+This is a simple e-commerce application that a customer can use to purchase a book, but it's missing the payments functionality — your goal is to integrate Stripe to get this application running!
 
 ## Candidate instructions
+
 You'll receive these in email.
 
 ## Application overview
+
 This demo is written in Javascript (Node.js) with the [Express framework](https://expressjs.com/). You'll need to retrieve a set of testmode API keys from the Stripe dashboard (you can create a free test account [here](https://dashboard.stripe.com/register)) to run this locally.
 
-We're using the [Bootstrap](https://getbootstrap.com/docs/4.6/getting-started/introduction/) CSS framework. It's the most popular CSS framework in the world and is pretty easy to get started with — feel free to modify styles/layout if you like. 
+We're using the [Bootstrap](https://getbootstrap.com/docs/4.6/getting-started/introduction/) CSS framework. It's the most popular CSS framework in the world and is pretty easy to get started with — feel free to modify styles/layout if you like.
 
-To simplify this project, we're also not using any database here, either. Instead `app.js` includes a simple switch statement to read the GET params for `item`. 
+To simplify this project, we're also not using any database here, either. Instead `app.js` includes a simple switch statement to read the GET params for `item`.
 
 To get started, clone the repository and run `npm install` to install dependencies:
 
@@ -27,3 +30,7 @@ npm start
 ```
 
 Navigate to [http://localhost:3000](http://localhost:3000) to view the index page.
+
+### SL Notes
+
+- https://docs.stripe.com/payments/quickstart?lang=node&client=html

--- a/app.js
+++ b/app.js
@@ -66,10 +66,25 @@ app.get('/success', function(req, res) {
 });
 
 const calculateOrderAmount = (items) => {
+  let amount;
+  switch (items[0].id) {
+    case '1':
+      amount = 2300
+      break;
+    case '2':
+      amount = 2500
+      break;
+    case '3':
+      amount = 2800
+      break;
+    default:
+      amount = 0
+      break;
+  }
   // Replace this constant with a calculation of the order's amount
   // Calculate the order total on the server to prevent
   // people from directly manipulating the amount on the client
-  return 1400;
+  return amount;
 };
 
 app.post("/create-payment-intent", async (req, res) => {

--- a/app.js
+++ b/app.js
@@ -65,6 +65,11 @@ app.get('/success', function(req, res) {
   res.render('success');
 });
 
+/**
+  // Calculate the amount to be paid per item and return it to the client
+ * @param {*} items 
+ * @returns amount to be charged
+ */
 const calculateOrderAmount = (items) => {
   let amount;
   switch (items[0].id) {
@@ -81,9 +86,7 @@ const calculateOrderAmount = (items) => {
       amount = 0
       break;
   }
-  // Replace this constant with a calculation of the order's amount
-  // Calculate the order total on the server to prevent
-  // people from directly manipulating the amount on the client
+
   return amount;
 };
 

--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -2,8 +2,8 @@
 // const stripe = Stripe(process.env.STRIPE_PUBLISHABLE_KEY);
 // const stripe = Stripe("pk_test_51PN6q42LxWzCRfRxa7jIqb4TBncTL5U3OPCuofI0qHfv0LnacVydqjTuEoYnEzogl26O5YHt3TJ7QcjEc17s6ftv005baoZ4pn");
 
-// The items the customer wants to buy
-const items = [{ id: "xl-tshirt" }];
+// Retrieve the items the customer wants to buy from search Param on Checkout page Load
+const item = { id: new URLSearchParams(window.location.search).get("item") };
 
 let elements;
 
@@ -19,7 +19,7 @@ async function initialize() {
   const response = await fetch("/create-payment-intent", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ items }),
+    body: JSON.stringify({ items: [item]  }),
   });
   const { clientSecret } = await response.json();
 

--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -1,0 +1,119 @@
+// This is your test publishable API key.
+// const stripe = Stripe(process.env.STRIPE_PUBLISHABLE_KEY);
+// const stripe = Stripe("pk_test_51PN6q42LxWzCRfRxa7jIqb4TBncTL5U3OPCuofI0qHfv0LnacVydqjTuEoYnEzogl26O5YHt3TJ7QcjEc17s6ftv005baoZ4pn");
+
+// The items the customer wants to buy
+const items = [{ id: "xl-tshirt" }];
+
+let elements;
+
+initialize();
+checkStatus();
+
+document
+  .querySelector("#payment-form")
+  .addEventListener("submit", handleSubmit);
+
+// Fetches a payment intent and captures the client secret
+async function initialize() {
+  const response = await fetch("/create-payment-intent", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ items }),
+  });
+  const { clientSecret } = await response.json();
+
+  const appearance = {
+    theme: 'stripe',
+  };
+  elements = stripe.elements({ appearance, clientSecret });
+
+  const paymentElementOptions = {
+    layout: "tabs",
+  };
+
+  const paymentElement = elements.create("payment", paymentElementOptions);
+  paymentElement.mount("#payment-element");
+}
+
+async function handleSubmit(e) {
+  e.preventDefault();
+  setLoading(true);
+
+  const { error } = await stripe.confirmPayment({
+    elements,
+    confirmParams: {
+      // Make sure to change this to your payment completion page
+      return_url: "http://localhost:3000/checkout.html",
+    },
+  });
+
+  // This point will only be reached if there is an immediate error when
+  // confirming the payment. Otherwise, your customer will be redirected to
+  // your `return_url`. For some payment methods like iDEAL, your customer will
+  // be redirected to an intermediate site first to authorize the payment, then
+  // redirected to the `return_url`.
+  if (error.type === "card_error" || error.type === "validation_error") {
+    showMessage(error.message);
+  } else {
+    showMessage("An unexpected error occurred.");
+  }
+
+  setLoading(false);
+}
+
+// Fetches the payment intent status after payment submission
+async function checkStatus() {
+  const clientSecret = new URLSearchParams(window.location.search).get(
+    "payment_intent_client_secret"
+  );
+
+  if (!clientSecret) {
+    return;
+  }
+
+  const { paymentIntent } = await stripe.retrievePaymentIntent(clientSecret);
+
+  switch (paymentIntent.status) {
+    case "succeeded":
+      showMessage("Payment succeeded!");
+      break;
+    case "processing":
+      showMessage("Your payment is processing.");
+      break;
+    case "requires_payment_method":
+      showMessage("Your payment was not successful, please try again.");
+      break;
+    default:
+      showMessage("Something went wrong.");
+      break;
+  }
+}
+
+// ------- UI helpers -------
+
+function showMessage(messageText) {
+  const messageContainer = document.querySelector("#payment-message");
+
+  messageContainer.classList.remove("hidden");
+  messageContainer.textContent = messageText;
+
+  setTimeout(function () {
+    messageContainer.classList.add("hidden");
+    messageContainer.textContent = "";
+  }, 4000);
+}
+
+// Show a spinner on payment submission
+function setLoading(isLoading) {
+  if (isLoading) {
+    // Disable the button and show a spinner
+    document.querySelector("#submit").disabled = true;
+    document.querySelector("#spinner").classList.remove("hidden");
+    document.querySelector("#button-text").classList.add("hidden");
+  } else {
+    document.querySelector("#submit").disabled = false;
+    document.querySelector("#spinner").classList.add("hidden");
+    document.querySelector("#button-text").classList.remove("hidden");
+  }
+}

--- a/views/checkout.hbs
+++ b/views/checkout.hbs
@@ -38,17 +38,15 @@
                 <div id="payment-element">
                   <!--Stripe.js injects the Payment Element-->
                 </div>
-                <button id="submit">
-                  <div class="spinner hidden" id="spinner"></div>
-                  <span id="button-text">Pay now</span>
-                </button>
+                <div class="mt-20">
+                  <button id="submit" type="submit" class="btn btn-lg btn-block btn-primary">Pay
+                    $<span class="amount" data-amount="{{amount}}"></span>
+                  </button>
+                </div>
                 <div id="payment-message" class="hidden"></div>
               </form>
             </div>
-            <div class="mt-20">
-              <button type="submit" class="btn btn-lg btn-block btn-primary">Pay $<span class="amount"
-                  data-amount="{{amount}}"></span></button>
-            </div>
+
           </form>
         </div>
       </div>

--- a/views/checkout.hbs
+++ b/views/checkout.hbs
@@ -1,32 +1,59 @@
-<div class="row justify-content-md-center">
-  <div class="col-6">
-    <div class="text-center mt-40">
-      <h1>
-        Checkout — Stripe Press
-      </h1>
-      <h5 class="text-secondary">
-        {{title}}
-      </h5>
-      <hr class="mt-40">
-      <div class="mt-20 text-info">
-        Total due: $<span class="amount" data-amount="{{amount}}"></span>
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Checkout — Stripe Press </title>
+  <script src="https://js.stripe.com/v3/"></script>
+  <script src="/js/checkout.js" defer></script>
+  <script>
+    // Initialize Stripe with the publishable key passed from the server
+    var stripe = Stripe('{{stripePublicKey}}');
+  </script>
+</head>
+
+<body>
+  <div class="row justify-content-md-center">
+    <div class="col-6">
+      <div class="text-center mt-40">
+        <h1>
+          Checkout — Stripe Press
+        </h1>
+        <h5 class="text-secondary">
+          {{title}}
+        </h5>
+        <hr class="mt-40">
+        <div class="mt-20 text-info">
+          Total due: $<span class="amount" data-amount="{{amount}}"></span>
+        </div>
       </div>
-    </div>
-    <div class="card box-shadow mt-40">
-      <div class="card-body">
-        <form name="payment-form">
-          <div>
-            <label for="email">Email address</label>
-            <input type="email" class="form-control" id="email" name="email" placeholder="you@email.com">
-          </div>
-          <div class="mt-20 text-center text-secondary border-placeholder">
-            Add Stripe Element here!
-          </div>
-          <div class="mt-20">
-            <button type="submit" class="btn btn-lg btn-block btn-primary">Pay $<span class="amount" data-amount="{{amount}}"></span></button>
-          </div>
-        </form>
+      <div class="card box-shadow mt-40">
+        <div class="card-body">
+          <form name="payment-form">
+            <div>
+              <label for="email">Email address</label>
+              <input type="email" class="form-control" id="email" name="email" placeholder="you@email.com">
+            </div>
+            <div class="mt-20 text-center text-secondary border-placeholder">
+              <form id="payment-form">
+                <div id="payment-element">
+                  <!--Stripe.js injects the Payment Element-->
+                </div>
+                <button id="submit">
+                  <div class="spinner hidden" id="spinner"></div>
+                  <span id="button-text">Pay now</span>
+                </button>
+                <div id="payment-message" class="hidden"></div>
+              </form>
+            </div>
+            <div class="mt-20">
+              <button type="submit" class="btn btn-lg btn-block btn-primary">Pay $<span class="amount"
+                  data-amount="{{amount}}"></span></button>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   </div>
-</div>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds basic stripe functionality to setup a intent to purchase from the checkout page.

- Add a rough location inside readme to start taking notes and link references
- In app.js initiated the stripe client with auth saved in local `.env` file for STRIPE_SECRET_KEY
- Passing the `STRIPE_PUBLISHABLE_KEY` as `stripePublicKey` to the checkout page from backend to pull JS elements from stripe.
- Update calculateAmount method setup earlier to have hard-coded values for each item, returns correct value based on item passed to it.
- New post endpoint created `/create-payment-intent` which creates a payment intent via `stripe.paymentIntents.create` method call

### Client Side Checkout handling
- A new checkout.js file has been setup inside public/js/checkout.js, this handles payment flow with stripe on the client side and communicates with backend as required. When the page is initalised the intent is automatically created using the item which was selected from URLSearchParams.
- The rest of the options are default as per reference from Stripe, this will be adjusted as required in subsequent PRs.
- The handling of the complete flow is yet to be done.
- The view `checkout.hbs` has been updated to load js.stripe.com/v3 as well as our internal checkout.js
- The form `payment-form` has been added to the existing code base and the stripe elements appear within this.
